### PR TITLE
🚚 Rename Library to GDrive Tools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 import setuptools
 
 setuptools.setup(
-  name="google-docs-library",
+  name="gdrive-tools",
   version="0.0.1",
   author="Robin Palkovits",
   author_email="robin.palkovits@5minds.de",
-  description="Lets the User Create New Documents in Nested Directories",
+  description="A collection of usefull tools to interact with the google drive/google docs api",
   packages=setuptools.find_packages(),
   classifiers=[
       "Programming Language :: Python :: 3",

--- a/src/gdrive_tools.py
+++ b/src/gdrive_tools.py
@@ -1,6 +1,4 @@
-from pathlib import Path
-
-class DocumentCreator():
+class GDriveTools():
 
   """
   Creates a new instance of the document creator. The identity is

--- a/testdoc.py
+++ b/testdoc.py
@@ -4,7 +4,7 @@ from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
-import src.document_creator as dc
+import src.gdrive_tools as gt
 
 # If modifying these scopes, delete the file token.pickle.
 SCOPES = ['https://www.googleapis.com/auth/documents',
@@ -12,12 +12,12 @@ SCOPES = ['https://www.googleapis.com/auth/documents',
 
 def main():
   docService, drvService = createServices()
-  documentCreator = dc.DocumentCreator(drvService, docService)
+  googleDriveTools = gt.GDriveTools(drvService, docService)
 
   clipboardId = '0ALjbkdGck0cgUk9PVA'
   dest = ['Testi', 'Test']
 
-  documentCreator.createFile(clipboardId, dest, 'bla', None)
+  googleDriveTools.createFile(clipboardId, dest, 'bla', None)
 
 def createServices():
   creds = None


### PR DESCRIPTION
## Changes

1. Renames the Library to Google Drive Tools

PR: #2
