### PR TITLE
✨ Let the User Provide the Name of the Target Shared Drive Instead of the Clipboard

### DIFF
--- a/src/gdrive_tools.py
+++ b/src/gdrive_tools.py
@@ -54,7 +54,7 @@ class GDriveTools():
 
     directoryTreeForFile = self.__buildDirectoryListForPath(directoriesFromClipboard, destination, sharedDriveId)
 
-    targetDirectoryId = directoryTreeForFile[-1] if len(directoryTreeForFile) > 0 else sharedDriveId
+    targetDirectoryId = directoryTreeForFile[-1].get('id') if len(directoryTreeForFile) > 0 else sharedDriveId
     if len(directoryTreeForFile) < len(destination):
       existingDirectoryNames = [curDir['name'] for curDir in directoryTreeForFile]
       missingDirectoryNames = [curDir for curDir in destination if curDir not in existingDirectoryNames]

--- a/src/gdrive_tools.py
+++ b/src/gdrive_tools.py
@@ -51,6 +51,7 @@ class GDriveTools():
     # Try to obtain the id of the drive with the given name
     sharedDriveId = self.__getIdOfSharedDrive(sharedDriveName)
     directoriesFromClipboard = self.__getAllDirectoriesFromClipboard(sharedDriveId)
+
     directoryTreeForFile = self.__buildDirectoryListForPath(directoriesFromClipboard, destination, sharedDriveId)
 
     targetDirectoryId = directoryTreeForFile[-1] if len(directoryTreeForFile) > 0 else sharedDriveId
@@ -90,7 +91,7 @@ class GDriveTools():
     files = self.__googleDriveClient \
       .files() \
       .list(
-        q="mimeType = 'application/vnd.google-apps.folder'",
+        q="mimeType = 'application/vnd.google-apps.folder' and not trashed",
         corpora='drive',
         supportsAllDrives=True,
         driveId=clipboardId,

--- a/src/gdrive_tools.py
+++ b/src/gdrive_tools.py
@@ -50,26 +50,16 @@ class GDriveTools():
 
     # Try to obtain the id of the drive with the given name
     sharedDriveId = self.__getIdOfSharedDrive(sharedDriveName)
-
-    print(sharedDriveId)
-
     directoriesFromClipboard = self.__getAllDirectoriesFromClipboard(sharedDriveId)
-
     directoryTreeForFile = self.__buildDirectoryListForPath(directoriesFromClipboard, destination, sharedDriveId)
 
-    print(directoriesFromClipboard)
-    print(directoryTreeForFile)
-
-    print('Create Target Directories')
     targetDirectoryId = directoryTreeForFile[-1] if len(directoryTreeForFile) > 0 else sharedDriveId
     if len(directoryTreeForFile) < len(destination):
       existingDirectoryNames = [curDir['name'] for curDir in directoryTreeForFile]
       missingDirectoryNames = [curDir for curDir in destination if curDir not in existingDirectoryNames]
-      print(missingDirectoryNames)
 
       targetDirectoryId = self.__createMissingDirectories(missingDirectoryNames, targetDirectoryId)
 
-    print('Create Document')
     # Create the Document
     createdDocumentId = self.__createDocument(documentName)
 

--- a/testdoc.py
+++ b/testdoc.py
@@ -17,7 +17,7 @@ def main():
   clipboardId = '0ALjbkdGck0cgUk9PVA'
   dest = ['Testi', 'Test']
 
-  googleDriveTools.createFile(clipboardId, dest, 'bla', None)
+  googleDriveTools.createFile('GDriveTools_Test', dest, 'bla', None)
 
 def createServices():
   creds = None


### PR DESCRIPTION
**Changes:**

1. The user is now able to provide the name of the shared clipboard, on which the new document should be created, instead of just the id.

1. Ignore all trashed folders for the shared drive.

1. Fixes a bug where a 404 error was thrown by the api if the target directory structure already existed. 

PR: #3
