### PR TITLE
Return the Id of a Moved or Copied Document

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ parameters are needed:
     * `GoogleFiletypes.SLIDE`: Google Slides file
 
 
+The method returns the id of the created document.
+
 ### Move a Document
 
 A document can be moved from one directory to another, either inside your
@@ -104,6 +106,8 @@ The following parameters are needed.
   moved to. The root point of this path points to the root directory of the
   shared drive with the name, defined by the `sourcePath` parameter.
 
+The method returns the id of the moved document.
+
 ### Copy a Document
 
 Its also possible to copy a document into another directory. This can
@@ -115,6 +119,8 @@ The following Parameters are required:
   The syntax is equivalent to the syntax of the `moveDocument()` Method.
 * `destinationPath(str)`: The path which defines where the copy of the source
   document should be created.
+
+The method returns the id of the copied document.
 
 ## Example
 

--- a/gdrive_tools/gdrive_tools.py
+++ b/gdrive_tools/gdrive_tools.py
@@ -90,7 +90,8 @@ class GDriveTools():
       sourcePath(str): The path of the document that should be moved.
       targetPath(str): The path where the document should be moved to.
     """
-    self.__moveDocument(sourcePath, targetPath)
+    movedDocumentId = self.__moveDocument(sourcePath, targetPath)
+    return movedDocumentId
 
   def copyDocument(self, sourcePath: str, targetPath: str):
     """
@@ -100,7 +101,8 @@ class GDriveTools():
       sourcePath(str): A reference to the document which should be copied.
       targetPath(str): The target path where the document should be copied to.
     """
-    self.__moveDocument(sourcePath, targetPath, copy=True)
+    copiedDocumentId = self.__moveDocument(sourcePath, targetPath, copy=True)
+    return copiedDocumentId
 
   def __moveDocument(self, sourcePath, targetPath, copy=False):
     sourcePathAsList, sourceFileName = self.__getPathAndFilename(sourcePath)
@@ -133,6 +135,8 @@ class GDriveTools():
       sourceDocumentId = copiedDocumentId
 
     self.__moveDocumentToDirectory(sourceDocumentId, targetDirectoryId, targetFileName=targetFileName)
+
+    return sourceDocumentId
 
   def __getDriveId(self, driveName):
     driveId = self.__getIdOfSharedDrive(driveName)

--- a/gdrive_tools/gdrive_tools.py
+++ b/gdrive_tools/gdrive_tools.py
@@ -42,6 +42,8 @@ class GDriveTools():
       type (int):             Type Identifier which defines the document type that
                               should be created.
 
+    Returns (str): The id of the created document.
+
     Todo:
       * Parse the Destination from any given input string into a list of directories.
         Currently, it is only supported to provide a list of directories instead of
@@ -89,6 +91,8 @@ class GDriveTools():
       sharedDriveName(str): Name of the Shared drive
       sourcePath(str): The path of the document that should be moved.
       targetPath(str): The path where the document should be moved to.
+
+    Returns str: The Id of the moved document.
     """
     movedDocumentId = self.__moveDocument(sourcePath, targetPath)
     return movedDocumentId
@@ -100,6 +104,8 @@ class GDriveTools():
     Args:
       sourcePath(str): A reference to the document which should be copied.
       targetPath(str): The target path where the document should be copied to.
+
+    Returns str: The Id of the moved document.
     """
     copiedDocumentId = self.__moveDocument(sourcePath, targetPath, copy=True)
     return copiedDocumentId


### PR DESCRIPTION
**Changes:**

1. The `moveDocument()` method now returns the id of the moved document.
2. The `copyDocument()` method now returns the id of the copied document.

PR: #26
