### PR TITLE
Add a Method to Return a Sheet's Content as a List of Dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,27 @@ The method takes the following parameters:
 * `[sheetTableName(str)='']` The name of the table inside the given sheet, where the data should
   be inserted.
   If the table does not exists, a `ValueError` will be thrown.
+
+### Read Data from a Sheet
+
+With the `readSheet()` method you can read the data from a sheet. The method
+will return a list of dictionaries which contains the sheets rows and columns.
+
+The target sheet has to contain only a single table without extra cells. Its assumed
+that the first row defines the names of the columns.
+However, its possible to specify a custom range in the A1 notation, where the
+table is placed.
+
+The method takes the following parameters:
+ * `sheetId(str)`: The id of the target sheet.
+ * `sheetName(str)`: The name of the table/sheet which should be used.
+ * `[a1Range(str)]`: A custom range which points to the data which should be read.
+    Since the sheet name is already passed with the sheetName property, you can't
+    also specify it here.
+* `[placeholder(dict)]`: A dictionary which contains placeholder values for each
+  column, which is not defined. A column is also considered as _not defined_, if
+  the value is an empty string.
+
 ### Grant Permissions
 
 You can grant Permissions to a given document by using the `grandApproval()` Method.

--- a/gdrive_tools/gdrive_tools.py
+++ b/gdrive_tools/gdrive_tools.py
@@ -175,7 +175,7 @@ class GDriveTools():
       else:
         raise
 
-  def readSheet(self, sheetId: str, sheetName: str, range=''):
+  def readSheet(self, sheetId: str, sheetName: str, a1Range='', placeholder=''):
     """
     Returns the content of the sheet with the passed sheetId as a List of Dictionaries.
     Its required, that the sheet only contains a static list. Its currently
@@ -183,13 +183,14 @@ class GDriveTools():
 
     Args:
       sheetId(str): The ID of the sheet, which should be returned.
-      [range(str)]: An optional range in A1 notation. Only the data in the given range will be included
+      [a1Range(str)]: An optional range in A1 notation. Only the data in the given range will be included
       into the output dict - list.
 
     Returns (str):
       The dictionary which contains the sheets content.
     """
-    a1Range = f"'{sheetName}'" if not range else range
+    a1Range = f"'{sheetName}'" if not a1Range else a1Range
+
     response = self.__googleSheetsClient\
       .spreadsheets()\
       .values()\

--- a/gdrive_tools/gdrive_tools.py
+++ b/gdrive_tools/gdrive_tools.py
@@ -175,7 +175,7 @@ class GDriveTools():
       else:
         raise
 
-  def readSheet(self, sheetId: str, sheetName: str, a1Range='', placeholder=''):
+  def readSheet(self, sheetId: str, sheetName: str, a1Range='', placeholder='{}'):
     """
     Returns the content of the sheet with the passed sheetId as a List of Dictionaries.
     Its required, that the sheet only contains a static list. Its currently
@@ -185,7 +185,7 @@ class GDriveTools():
       sheetId(str): The ID of the sheet, which should be returned.
       [a1Range(str)]: An optional range in A1 notation. Only the data in the given range will be included
       into the output dict - list.
-      [placeholder(str)]: Defines a placeholder value which should be inserted for each undefined cell.
+      [placeholder(dict)]: A dictionary which contains placeholder values.
 
     Returns (str):
       The dictionary which contains the sheets content.
@@ -522,13 +522,15 @@ class GDriveTools():
     columns = data[0]
     outList = []
 
-    for currentData in data[1:]:
+    for rowIndex, currentData in enumerate(data[1:]):
       dictToAppend = {}
       for index, currentColumn in enumerate(columns):
-        if index < len(currentData):
+        if index < len(currentData) and currentData[index]:
           dictToAppend[currentColumn] = currentData[index]
+        elif currentColumn in placeholder:
+          dictToAppend[currentColumn] = placeholder[currentColumn]
         else:
-          dictToAppend[currentColumn] = placeholder
+          raise ValueError(f'Undefined column named "{currentColumn}" in row {rowIndex}')
 
       outList.append(dictToAppend)
 

--- a/gdrive_tools/gdrive_tools.py
+++ b/gdrive_tools/gdrive_tools.py
@@ -182,10 +182,14 @@ class GDriveTools():
     not supported to process sheets contains extra cells.
 
     Args:
-      sheetId(str): The ID of the sheet, which should be returned.
-      [a1Range(str)]: An optional range in A1 notation. Only the data in the given range will be included
-      into the output dict - list.
-      [placeholder(dict)]: A dictionary which contains placeholder values.
+      sheetId(str): The id of the target sheet.
+      sheetName(str): The name of the table/sheet which should be used.
+      [a1Range(str)]: A custom range which points to the data which should be read.
+        Since the sheet name is already passed with the sheetName property, you can't
+        also specify it here.
+      [placeholder(dict)]: A dictionary which contains placeholder values for each
+        column, which is not defined. A column is also considered as _not defined_, if
+        the value is an empty string.
 
     Returns (str):
       The dictionary which contains the sheets content.

--- a/gdrive_tools/gdrive_tools.py
+++ b/gdrive_tools/gdrive_tools.py
@@ -185,6 +185,7 @@ class GDriveTools():
       sheetId(str): The ID of the sheet, which should be returned.
       [a1Range(str)]: An optional range in A1 notation. Only the data in the given range will be included
       into the output dict - list.
+      [placeholder(str)]: Defines a placeholder value which should be inserted for each undefined cell.
 
     Returns (str):
       The dictionary which contains the sheets content.
@@ -198,7 +199,7 @@ class GDriveTools():
       .execute()
 
     sheetValues = response['valueRanges'][0]['values']
-    sheetAsDict = self.__generateDictFromList(sheetValues)
+    sheetAsDict = self.__generateDictFromList(sheetValues, placeholder)
 
     return sheetAsDict
 
@@ -516,7 +517,7 @@ class GDriveTools():
     return columns, values
 
   @staticmethod
-  def __generateDictFromList(data):
+  def __generateDictFromList(data, placeholder):
     # We can assume that the first row always contains the field names.
     columns = data[0]
     outList = []
@@ -524,7 +525,10 @@ class GDriveTools():
     for currentData in data[1:]:
       dictToAppend = {}
       for index, currentColumn in enumerate(columns):
-        dictToAppend[currentColumn] = currentData[index]
+        if index < len(currentData):
+          dictToAppend[currentColumn] = currentData[index]
+        else:
+          dictToAppend[currentColumn] = placeholder
 
       outList.append(dictToAppend)
 

--- a/gdrive_tools/gdrive_tools.py
+++ b/gdrive_tools/gdrive_tools.py
@@ -194,7 +194,7 @@ class GDriveTools():
     Returns (str):
       The dictionary which contains the sheets content.
     """
-    a1Range = f"'{sheetName}'" if not a1Range else a1Range
+    a1Range = f"'{sheetName}'" if not a1Range else f"'{sheetName}'!{a1Range}"
 
     response = self.__googleSheetsClient\
       .spreadsheets()\


### PR DESCRIPTION
**Changes:**

1. Adds the `readSheet()` method which takes a sheetId and exports all data from the given sheetName as a list of dictionaries.

PR: #28 
