### PR TITLE
Remove the ValueError Exception on an Unexpected Empty Cell

### DIFF
--- a/gdrive_tools/gdrive_tools.py
+++ b/gdrive_tools/gdrive_tools.py
@@ -561,7 +561,7 @@ class GDriveTools():
         elif currentColumn in placeholder:
           dictToAppend[currentColumn] = placeholder[currentColumn]
         else:
-          raise ValueError(f'Undefined column named "{currentColumn}" in row {rowIndex}')
+          dictToAppend[currentColumn] = None
 
       outList.append(dictToAppend)
 

--- a/gdrive_tools/gdrive_tools.py
+++ b/gdrive_tools/gdrive_tools.py
@@ -553,7 +553,7 @@ class GDriveTools():
     columns = data[0]
     outList = []
 
-    for rowIndex, currentData in enumerate(data[1:]):
+    for currentData in data[1:]:
       dictToAppend = {}
       for index, currentColumn in enumerate(columns):
         if index < len(currentData) and currentData[index]:


### PR DESCRIPTION
**Changes:**

1. Removes the `ValueError` exception which is thrown by the `readSheet()` method which was thrown if a cell was empty and no placeholder for this cell was set by the user. 
Instead, the value is set to _None_.

**Issues:**

Closes #32 

PR: #33 
