### PR TITLE
Replace the Plain MimeType from the readDirectory Method with an Enum Instance

### DIFF
--- a/gdrive_tools/gdrive_tools.py
+++ b/gdrive_tools/gdrive_tools.py
@@ -250,7 +250,8 @@ class GDriveTools():
     retDict['directory_id'] = directoryId
 
     for currentFile in filesFromDir:
-      currentFile['type'] = currentFile.pop('mimeType')
+      mimeType = currentFile.pop('mimeType')
+      currentFile['type'] = self.__convertMimeType(mimeType)
 
     retDict['files'] = filesFromDir
 
@@ -677,3 +678,28 @@ class GDriveTools():
       outList.append(dictToAppend)
 
     return outList
+
+  @staticmethod
+  def __convertMimeType(mimeType):
+    if mimeType == 'application/vnd.google-apps.document':
+      return GoogleFiletypes.DOCUMENT
+    elif mimeType == 'application/vnd.google-apps.spreadsheet':
+      return GoogleFiletypes.SHEET
+    elif mimeType == 'application/vnd.google-apps.presentation':
+      return GoogleFiletypes.SLIDE
+    elif mimeType == 'application/vnd.google-apps.drawing':
+      return GoogleFiletypes.DRAWING
+    elif mimeType == 'application/vnd.google-apps.form':
+      return GoogleFiletypes.FORM
+    elif mimeType == 'application/vnd.google-apps.fusiontable':
+      return GoogleFiletypes.FUSIONTABLE
+    elif mimeType == 'application/vnd.google-apps.map':
+      return GoogleFiletypes.MAP
+    elif mimeType == 'application/vnd.google-apps.script':
+      return GoogleFiletypes.APPSCRIPT
+    elif mimeType == 'application/vnd.google-apps.site':
+      return GoogleFiletypes.SITE
+    elif mimeType == 'application/vnd.google-apps.drive-sdk':
+      return GoogleFiletypes.DRIVESDK
+    else:
+      return GoogleFiletypes.FILE

--- a/gdrive_tools/gdrive_tools.py
+++ b/gdrive_tools/gdrive_tools.py
@@ -485,7 +485,9 @@ class GDriveTools():
       createdFileId = self.__createSlide(name)
 
     else:
-      raise ValueError('The Given Filetype is not valid!')
+      message = "The given Filetype is currently not supported. Supported filetypes are: "\
+        "DOCUMENT, SHEET and SLIDE."
+      raise ValueError(message)
 
     return createdFileId
 

--- a/gdrive_tools/google_filetypes.py
+++ b/gdrive_tools/google_filetypes.py
@@ -4,3 +4,11 @@ class GoogleFiletypes(Enum):
   DOCUMENT=1
   SHEET=2
   SLIDE=3
+  DRAWING=4
+  FORM=5
+  FUSIONTABLE=6
+  MAP=7
+  APPSCRIPT=10
+  SITE=11
+  DRIVESDK=13
+  FILE=14


### PR DESCRIPTION
**Changes:**

1. Replaces the mimeType, which is returned by the `readDirectory()` method for each file with an instance of the according enum - type.

PR: #37 
