### PR TITLE
✨ Make the Token Path and File Name Configurable

### DIFF
--- a/gdrive_tools/google_auth.py
+++ b/gdrive_tools/google_auth.py
@@ -5,9 +5,11 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 class GoogleAuth():
-  def __init__(self, scopes, credentialsPath='credentials.json'):
+  def __init__(self, scopes, credentialsPath='credentials.json', tokenPath=".", tokenFileName="token.pickle"):
     self.__scopes = scopes
     self.__credentialsPath = credentialsPath
+    self.__tokenPath = tokenPath
+    self.__tokenFileName = tokenFileName
 
   def createCredentials(self):
     creds = None
@@ -15,9 +17,10 @@ class GoogleAuth():
     # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    if os.path.exists('token.pickle'):
-        with open('token.pickle', 'rb') as token:
-            creds = pickle.load(token)
+    tokenPath = f'{self.__tokenPath}/{self.__tokenFileName}'
+    if os.path.exists(tokenPath):
+      with open(tokenPath, 'rb') as token:
+        creds = pickle.load(token)
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
       if creds and creds.expired and creds.refresh_token:
@@ -27,7 +30,7 @@ class GoogleAuth():
         creds = flow.run_local_server(port=0)
 
       # Save the credentials for the next run
-      with open('token.pickle', 'wb') as token:
+      with open(tokenPath, 'wb') as token:
         pickle.dump(creds, token)
 
     return creds


### PR DESCRIPTION
**Changes:**

1. Makes the token path and filename configurable. With the following keyword arguments on the `GoogleAuth`  constructor, it is now possible to configure, where the token should be stored and which file name the pickled token file should have. 
  * `tokenPath`: Path, where the pickled token file should be stored
  * `tokenFileName`: Name of the pickled token file. 

PR: #?
